### PR TITLE
Correct case of filename in #include directive

### DIFF
--- a/src/TTN_esp32.h
+++ b/src/TTN_esp32.h
@@ -4,7 +4,7 @@
 #define _TTN_ESP32_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/lorawan_esp32.h
+++ b/src/lorawan_esp32.h
@@ -4,7 +4,7 @@
 #define _LORAWAN_ESP32_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.